### PR TITLE
add selector

### DIFF
--- a/src/components/AccountSelector/AccountSelectButton/AccountSelector.stories.tsx
+++ b/src/components/AccountSelector/AccountSelectButton/AccountSelector.stories.tsx
@@ -1,0 +1,19 @@
+import { FiUser } from "react-icons/fi";
+import { MassaToken } from "../../../assets/svg-components/MassaToken";
+import { AccountSelectorButton } from "./AccountSelectorButton";
+
+export default {
+  title: "Components/Account Selector",
+  component: AccountSelectorButton,
+};
+
+const args = {
+  avatar: <FiUser className="text-neutral h-6 w-6" />,
+  accountName: "account #",
+  icon: <MassaToken size={24} />,
+  amount: "0,000.00",
+};
+
+export const _AccountSelector = {
+  render: () => <AccountSelectorButton {...args} />,
+};

--- a/src/components/AccountSelector/AccountSelectButton/AccountSelector.test.tsx
+++ b/src/components/AccountSelector/AccountSelectButton/AccountSelector.test.tsx
@@ -1,0 +1,36 @@
+import { render, fireEvent, screen } from "@testing-library/react";
+import { AccountSelectorButton } from "./AccountSelectorButton";
+import { FiUser, FiAlertTriangle } from "react-icons/fi";
+
+describe("Components | Buttons | Account Selector", () => {
+  test("it should render", () => {
+    const args = {
+      avatar: <FiUser className="text-neutral" />,
+      accountName: "account #",
+      icon: <FiAlertTriangle />,
+      amount: "0,000.00",
+    };
+    render(<AccountSelectorButton {...args} />);
+
+    let accountSelector = screen.getByTestId("account-selector-button");
+
+    expect(accountSelector).toBeTruthy();
+  });
+
+  test("it fire the onClick fn", () => {
+    const onClickMock = jest.fn();
+    const args = {
+      avatar: <FiUser className="text-neutral" />,
+      accountName: "account #",
+      icon: <FiAlertTriangle />,
+      amount: "0,000.00",
+    };
+    render(<AccountSelectorButton onClick={onClickMock} {...args} />);
+
+    let accountSelector = screen.getByTestId("account-selector-button");
+
+    fireEvent.click(accountSelector);
+    expect(onClickMock).toHaveBeenCalled();
+    expect(accountSelector).toBeTruthy();
+  });
+});

--- a/src/components/AccountSelector/AccountSelectButton/AccountSelectorButton.tsx
+++ b/src/components/AccountSelector/AccountSelectButton/AccountSelectorButton.tsx
@@ -1,0 +1,51 @@
+import { ComponentPropsWithoutRef } from "react";
+
+export interface AccountSelectorProps extends ComponentPropsWithoutRef<"div"> {
+  avatar: React.ReactNode;
+  accountName: string;
+  icon: React.ReactNode;
+  amount: string;
+  children?: React.ReactNode;
+}
+
+export function AccountSelectorButton(props: AccountSelectorProps) {
+  let { avatar, accountName, icon, amount, children, ...rest } = props;
+
+  const accountSelectorClass = "flex flex-row items-center justify-between";
+
+  const hoverClass = `hover:bg-info`;
+  const activeClass = `active:bg-c-pressed`;
+
+  const containerFlexClass = "flex justify-center items-center";
+
+  return (
+    <div
+      className={`bg-neutral text-primary h-14 w-full p-3 rounded-lg mas-menu-active cursor-pointer 
+                      ${accountSelectorClass} 
+                      ${hoverClass} 
+                      ${activeClass}`}
+      {...props}
+      data-testid="account-selector-button"
+    >
+      <div className={`${containerFlexClass}`}>
+        <div
+          className={`bg-primary h-8 w-8 rounded-full mr-2
+                           ${containerFlexClass}`}
+        >
+          {avatar}
+        </div>
+        <div>{accountName}</div>
+      </div>
+
+      <div className={`${containerFlexClass}`}>
+        <div
+          className={`mr-2 bg-primary h-6 w-6 rounded-full
+                          ${containerFlexClass}`}
+        >
+          {icon}
+        </div>
+        <div>{amount}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/AccountSelector/AccountSelectButton/index.ts
+++ b/src/components/AccountSelector/AccountSelectButton/index.ts
@@ -1,0 +1,1 @@
+export * from "./AccountSelectorButton";

--- a/src/components/AccountSelector/index.ts
+++ b/src/components/AccountSelector/index.ts
@@ -1,0 +1,1 @@
+export * from "./AccountSelectButton";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,4 @@
+export * from "./AccountSelector";
 export * from "./Password";
 export * from "./Input";
 export * from "./Button";


### PR DESCRIPTION
<img width="409" alt="Screenshot 2023-05-05 at 20 02 13" src="https://user-images.githubusercontent.com/90157528/236533902-21ca6496-c99a-42a4-9530-d2f6b15b3f84.png">

This is a cleaner branch than [32-add-account-selector](https://github.com/massalabs/Ui-Kit/tree/32-add-account-selector) ! Once merged I will delete previous.