### PR TITLE
remove index export

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,4 +2,3 @@ export * from "./AccountSelector";
 export * from "./Password";
 export * from "./Input";
 export * from "./Button";
-export * from "./Icons";


### PR DESCRIPTION
The index export show an error. We remove it because there is no Icon or SVG component to export.  