### PR TITLE
remove leading normal to fix displacement

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -30,7 +30,7 @@ export function Button(props: ButtonProps) {
       `}
       {...rest}
     >
-      <div className="w-fit m-auto flex gap-2 leading-normal">
+      <div className="w-fit m-auto flex gap-2">
         <div className="m-auto">
           <IconContext.Provider value={{ className: "w-6 h-6" }}>
             {preIcon}


### PR DESCRIPTION
Quick fix for the text displacement of the button. The issue was that : 
- the leading normal was setting line height to 1px on buttons and over-riding the line-height : 20px set in the presets. 

Here we can see the text is not centered : 
![Screenshot from 2023-05-11 10-39-02](https://github.com/massalabs/ui-kit/assets/90157528/d5eb8a86-2224-48bc-9f2a-ada82ffd04d2)

Removing leading normal should fix and recenter 
