### PR TITLE
fix flags size

### DIFF
--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -104,7 +104,7 @@ export const _Dropdown = {
             },
             {
               icon: (
-                <div className="w-7">
+                <div className="w-4">
                   <BrazilFlag />
                 </div>
               ),
@@ -112,7 +112,7 @@ export const _Dropdown = {
             },
             {
               icon: (
-                <div className="w-7">
+                <div className="w-4">
                   <ItalyFlag />
                 </div>
               ),


### PR DESCRIPTION
We miss some size update on dropdown storybook. This MR fixed that:

|before|after|
|-|-|
| <img width="264" alt="Screenshot 2023-05-16 at 11 31 46" src="https://github.com/massalabs/ui-kit/assets/126461030/0c5432f4-69ce-4275-8e91-3291132e3f1a"> | <img width="270" alt="Screenshot 2023-05-16 at 11 31 22" src="https://github.com/massalabs/ui-kit/assets/126461030/7222c844-38e5-4eca-b8ca-1e4cfa683b6c"> |
