### PR TITLE
add error under password field

### DIFF
--- a/src/components/Password/Password.stories.tsx
+++ b/src/components/Password/Password.stories.tsx
@@ -3,5 +3,15 @@ import { Password } from "./Password";
 export default { title: "Components/Password", component: Password };
 
 export const _Password = {
-  render: () => <Password placeholder={"password"} />,
+  render: () => (
+    <>
+      <Password placeholder={"something"} />
+      <br />
+
+      <Password placeholder={"something"} error="that's an error" />
+      <br />
+
+      <Password placeholder={"something"} warning="that's a warning" />
+    </>
+  ),
 };

--- a/src/components/Password/Password.test.tsx
+++ b/src/components/Password/Password.test.tsx
@@ -19,6 +19,28 @@ describe("Components | Fields | Password", () => {
     expect(input).toBeTruthy();
   });
 
+  test("it should show an error message", () => {
+    render(<Password error={"euh"} />);
+
+    let message = screen.getByTestId("input-field-message");
+    let input = screen.getByTestId("password-input");
+
+    expect(message).toBeInTheDocument();
+    expect(message.getAttribute("class")).toContain("text-s-error");
+    expect(input.getAttribute("class")).toContain("border-s-error");
+  });
+
+  test("it should show an warning message", () => {
+    render(<Password warning={"warn"} />);
+
+    let message = screen.getByTestId("input-field-message");
+    let input = screen.getByTestId("password-input");
+
+    expect(message).toBeInTheDocument();
+    expect(message.getAttribute("class")).toContain("text-s-warning");
+    expect(input.getAttribute("class")).toContain("border-s-warning");
+  });
+
   test("it should show/hide the input content when switching between eye mode", () => {
     render(<Password placeholder={"something"} />);
 

--- a/src/components/Password/Password.tsx
+++ b/src/components/Password/Password.tsx
@@ -4,15 +4,20 @@ import React from "react";
 
 import { useState, ComponentPropsWithoutRef } from "react";
 import { FiEyeOff, FiEye } from "react-icons/fi";
+import { InputMessage } from "../index";
 
 export interface PasswordProps extends ComponentPropsWithoutRef<"input"> {
-  placeholder?: string;
+  error?: string | undefined;
+  warning?: string | undefined;
 }
 
 export function Password(props: PasswordProps) {
-  const { placeholder, ...rest } = props;
+  const { error, warning, ...rest } = props;
 
-  let iconClass = `w-5 h-5 inline-block align-text-bottom text-neutral`;
+  const errorClass = error ? "border-s-error" : "";
+  const warningClass = warning ? "border-s-warning" : "";
+  const messageClass = errorClass || warningClass;
+  const iconClass = `w-5 h-5 inline-block align-text-bottom text-neutral`;
 
   let open = {
     type: "text",
@@ -44,9 +49,8 @@ export function Password(props: PasswordProps) {
         <div className="inline h-12">
           <input
             data-testid="password-input"
-            className={`w-full default-input`}
+            className={`w-full default-input mb-1 ${messageClass}`}
             type={type}
-            placeholder={placeholder}
             {...rest}
           />
         </div>
@@ -59,6 +63,7 @@ export function Password(props: PasswordProps) {
             {icon}
           </button>
         </div>
+        <InputMessage error={error} warning={warning} />
       </div>
     </div>
   );


### PR DESCRIPTION
We are adding the error/warning API for `<Password>` component. 

<img width="756" alt="Screenshot 2023-05-22 at 18 27 08" src="https://github.com/massalabs/ui-kit/assets/126461030/3f511572-0270-4fe8-9c13-390f262d91ca">


