### PR TITLE
fix modal close button color

### DIFF
--- a/src/components/PopupModal/PopupModal.tsx
+++ b/src/components/PopupModal/PopupModal.tsx
@@ -47,7 +47,7 @@ export function PopupModalHeader(props: IPopupModalNodeProps) {
         <button
           data-testid="popup-modal-header-close"
           className="text-neutral bg-primary rounded-lg text-sm p-1.5 ml-auto inline-flex items-center
-                      hover:bg-c-hover hover:text-c-primary"
+                      hover:bg-tertiary hover:text-c-primary"
           type="button"
           onClick={handleClose}
         >


### PR DESCRIPTION
We are fixing the close button color on modal

|before|after|
|-|-|
|<img width="151" alt="Screenshot 2023-05-25 at 10 42 48" src="https://github.com/massalabs/ui-kit/assets/126461030/32ac83da-1d02-4f49-9de1-15ff991b47b1">|<img width="171" alt="Screenshot 2023-05-25 at 10 42 07" src="https://github.com/massalabs/ui-kit/assets/126461030/e3be0d4c-6f45-4cb2-96bd-0c335cbfd825">|

