### PR TITLE
fix side menu typo items

### DIFF
--- a/src/components/SideMenu/SideMenu.tsx
+++ b/src/components/SideMenu/SideMenu.tsx
@@ -69,7 +69,7 @@ export function LongItem(props: ILongItemProps) {
         onClick={onClickItem}
       >
         {clonedIcon}
-        <span className="ml-2 mas-menu-active">{label}</span>
+        <span className="ml-2 mas-menu-default">{label}</span>
       </div>
     </>
   );


### PR DESCRIPTION
We are fixing trick typo on side menu.

![image](https://github.com/massalabs/ui-kit/assets/72019005/6a812602-f88b-4442-a590-e532f84aa1e7)

TO

![image](https://github.com/massalabs/ui-kit/assets/72019005/59038c1c-b851-4a87-b7cf-ff77d4b80dee)
