### PR TITLE
add typescript

### DIFF
--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -3,5 +3,6 @@ module.exports = {
     '@babel/preset-env',
     ['@babel/preset-react', { runtime: 'automatic' }],
     '@babel/preset-flow',
+    '@babel/preset-typescript',
   ],
 };


### PR DESCRIPTION
When we run tests with jest when files have "usestate<T>" (eg: usestate<string>)  we need this config.