### PR TITLE
Button: add classname as props

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -25,14 +25,16 @@ export function Button(props: ButtonProps) {
                           active:bg-neutral/[.3]                                                  
                           disabled:text-f-disabled-1 disabled:bg-c-disabled-2 disabled:border-c-disabled-1`;
 
-  const buttonClass = variant ? secondaryClass : primaryClass;
+  let className = variant ? secondaryClass : primaryClass;
+
+  if (props.className) className = className + ' ' + props.className;
 
   return (
     <button
       data-testid="button"
       type="button"
       {...rest}
-      className={`default-button px-4 py-3 ${buttonClass}`}
+      className={`default-button px-4 py-3 ${className}`}
     >
       <div className="w-fit m-auto flex gap-2 items-baseline">
         <div className="m-auto">


### PR DESCRIPTION
this would allow me to do:

```tsx
<Button className="w-full" variant="secondary" preIcon={<FiPlus />}>
  {Intl.t('account.add')}
</Button>
```

because `w-full` as been removed from the Button component, I need to add it in some places.