### PR TITLE
missing round lg on massa wallet logo

### DIFF
--- a/src/components/Icons/Svg/Massa/MassaWallet.tsx
+++ b/src/components/Icons/Svg/Massa/MassaWallet.tsx
@@ -52,7 +52,11 @@ function Squared(props: SVGProps) {
   let { size, ...rest } = props;
 
   return (
-    <div className={`bg-primary w-fit`} data-testid="svg-icon" {...rest}>
+    <div
+      className={`bg-primary w-fit rounded-lg`}
+      data-testid="svg-icon"
+      {...rest}
+    >
       <svg
         width={size ?? 40}
         height={size ?? 40}


### PR DESCRIPTION
We missed a rounded in wallet massa logo. This MR fixed that.