### PR TITLE
Add Correct Padding to Layout

### DIFF
--- a/src/components/LayoutStation/LayoutStation.tsx
+++ b/src/components/LayoutStation/LayoutStation.tsx
@@ -34,7 +34,7 @@ export function LayoutStation({ ...props }) {
   return (
     <div
       data-testid="layout-station"
-      className={`bg-primary h-screen ${customClass}`}
+      className={`bg-primary h-screen px-20 pt-12 pb-8 ${customClass}`}
     >
       <div className="grid grid-cols-3">
         <div className="flex flex-row justify-start">


### PR DESCRIPTION
We add correct padding to layout component :
80px on x axis,
48 on top 
32 on bot

Before : 
![Screenshot from 2023-06-12 15-58-18](https://github.com/massalabs/ui-kit/assets/90157528/ed8c364d-1d6a-4ef5-bb2d-c38bed9a0063)

After :
![Screenshot from 2023-06-12 15-58-08](https://github.com/massalabs/ui-kit/assets/90157528/2ed45bec-955a-43e1-a999-ca3f62380de2)

