### PR TITLE
Add min-h to Layout

### DIFF
--- a/src/components/LayoutStation/LayoutStation.tsx
+++ b/src/components/LayoutStation/LayoutStation.tsx
@@ -34,7 +34,7 @@ export function LayoutStation({ ...props }) {
   return (
     <div
       data-testid="layout-station"
-      className={`bg-primary px-20 pt-12 pb-8 ${customClass}`}
+      className={`min-h-screen bg-primary px-20 pt-12 pb-8 ${customClass}`}
     >
       <div className="grid grid-cols-3">
         <div className="flex flex-row justify-start">


### PR DESCRIPTION
There was a change on the layout height that introduced unexpected behavior. This pr is a correction so set min h-screen and not block the scroll. It is so we don't have to set the h-screen in children component see example : 

no h-screen in component 
![Screenshot from 2023-06-14 17-18-26](https://github.com/massalabs/ui-kit/assets/90157528/70813173-0001-4439-ba43-2092fb345e0c)

with min-h-screen : 
![Screenshot from 2023-06-14 17-19-03](https://github.com/massalabs/ui-kit/assets/90157528/781ed36b-5ff0-4a9b-bfb1-3c54c37566f1)

