### PR TITLE
Add null to subtitleIcon

### DIFF
--- a/src/components/Plugin/Plugin.tsx
+++ b/src/components/Plugin/Plugin.tsx
@@ -9,7 +9,7 @@ export interface PluginProps {
   topAction: JSX.Element;
   title: string;
   subtitle?: string;
-  subtitleIcon?: JSX.Element;
+  subtitleIcon?: JSX.Element | null;
   content: string | ReactNode[];
   variant?: string;
   customClass?: string;


### PR DESCRIPTION
We try to fix an error that appears when using the component 
`Type '{ preIcon: Element; topAction: Element; title: string; subtitle: string; subtitleIcon: Element; content: (false | Element)[]; } | { preIcon: Element; ... 4 more ...; content: Element[]; }' is not assignable to type 'IntrinsicAttributes & PluginProps'.
  Type '{ preIcon: Element; topAction: Element; title: string; subtitle: string; subtitleIcon: Element | null; content: Element[]; }' is not assignable to type 'PluginProps'.
    Types of property 'subtitleIcon' are incompatible.
      Type 'Element | null' is not assignable to type 'Element | undefined'.
        Type 'null' is not assignable to type 'Element | undefined'.` 

because we add a conditional in our subtitleIcon to render or not the the certificate icon :
`subtitleIcon: author === 'MassaLabs' ? <Certificate /> : <></>,`

