### PR TITLE
Add Camel Case to SVG

### DIFF
--- a/src/components/Icons/Svg/Massa/Certificate.tsx
+++ b/src/components/Icons/Svg/Massa/Certificate.tsx
@@ -56,8 +56,8 @@ export function Certificate(props: SVGProps) {
         <path
           d="M11.3333 6L7.66667 9.66595L6 7.99961"
           stroke="white"
-          stroke-linecap="round"
-          stroke-linejoin="round"
+          strokeLinecap="round"
+          strokeLinejoin="round"
         />
       </svg>
     </>


### PR DESCRIPTION
We add camelCase to fix error 
`act-dom.development.js:86 Warning: Invalid DOM property `stroke-linejoin`. Did you mean `strokeLinejoin`?
    at path
    at svg
    at Certificate (http://localhost:5173/node_modules/.vite/deps/@massalabs_react-ui-kit.js?t=1686752369481&v=9a032a34:799:9)
 `