### PR TITLE
fix display when text contain underscore

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -117,7 +117,7 @@ export function Dropdown(props: IDropdownProps) {
                   </div>
                   <div
                     data-testid={`dropdown-item-${idx}`}
-                    className="mas-menu-active truncate"
+                    className="mas-menu-active p-2 truncate"
                   >
                     {option.item}
                   </div>


### PR DESCRIPTION
We are fixing display of underscore for text in dopdown list.

**BEFORE**
![image](https://github.com/massalabs/ui-kit/assets/72019005/ab2f38b1-8791-4a89-b9db-52ea21232b6c)

**AFTER**
![image](https://github.com/massalabs/ui-kit/assets/72019005/388b632e-77e5-47e7-9c8f-7188dbf19534)
