### PR TITLE
Add hover to clipboard

### DIFF
--- a/src/components/Clipboard/Clipboard.tsx
+++ b/src/components/Clipboard/Clipboard.tsx
@@ -1,6 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
-import React from 'react';
+import React, { CSSProperties } from 'react';
 
 import { useState, ComponentPropsWithoutRef } from 'react';
 import { FiCopy, FiCheckCircle } from 'react-icons/fi';
@@ -16,6 +16,7 @@ interface ClipboardProps extends ComponentPropsWithoutRef<'div'> {
   error?: string;
   success?: string;
   customClass?: string;
+  toggleHover?: boolean;
 }
 
 export function Clipboard(props: ClipboardProps) {
@@ -25,11 +26,17 @@ export function Clipboard(props: ClipboardProps) {
     rawContent,
     displayedContent = rawContent,
     customClass,
+    toggleHover,
     ...rest
   } = props;
 
   const [success, setSuccess] = useState(false);
   const [error, setError] = useState(false);
+  // check to see if mouse is hovering over the component
+  const [isHovered, setIsHovered] = useState(false);
+  // check params, if undefiend, set to true in handleHover function
+  const [hover, setHover] = useState(toggleHover);
+  const [position, setPosition] = useState({ x: 0, y: 0 });
 
   function handleCopyToClipboard() {
     setError(false);
@@ -40,7 +47,6 @@ export function Clipboard(props: ClipboardProps) {
       return;
     }
 
-    //
     copy(rawContent);
 
     setSuccess(true);
@@ -50,12 +56,38 @@ export function Clipboard(props: ClipboardProps) {
     }, 3000);
   }
 
+  function renderAddressHover() {
+    const divStyle: CSSProperties = {
+      position: 'fixed',
+      left: position.x + 30,
+      top: position.y - 30,
+    };
+
+    return (
+      <p
+        style={divStyle}
+        className="relative bg-secondary z-10 top-2 text-f-primary pr-2 w-fit truncate pointer-events-none px-1 rounded"
+      >
+        {rawContent}
+      </p>
+    );
+  }
+
+  function handleHover(bool: boolean) {
+    if (toggleHover === undefined) setHover(true);
+    setIsHovered(bool);
+  }
+
   return (
     <>
+      {isHovered && hover ? renderAddressHover() : null}
       <div
         data-testid="clipboard-field"
         className={`flex flex-row items-center mas-body2 justify-between w-full
         h-12 px-3 rounded bg-secondary cursor-pointer ${customClass}`}
+        onMouseEnter={() => handleHover(true)}
+        onMouseLeave={() => handleHover(false)}
+        onMouseMove={(e) => setPosition({ x: e.clientX, y: e.clientY })}
         onClick={handleCopyToClipboard}
         {...rest}
       >

--- a/src/components/Clipboard/Clipboard.tsx
+++ b/src/components/Clipboard/Clipboard.tsx
@@ -56,7 +56,7 @@ export function Clipboard(props: ClipboardProps) {
     }, 3000);
   }
 
-  function renderAddressHover() {
+  function displayAddressOnHover() {
     const divStyle: CSSProperties = {
       position: 'fixed',
       left: position.x + 30,
@@ -80,7 +80,7 @@ export function Clipboard(props: ClipboardProps) {
 
   return (
     <>
-      {isHovered && hover ? renderAddressHover() : null}
+      {isHovered && hover ? displayAddressOnHover() : null}
       <div
         data-testid="clipboard-field"
         className={`flex flex-row items-center mas-body2 justify-between w-full


### PR DESCRIPTION
[Screencast from 04-07-2023 17:50:18.webm](https://github.com/massalabs/ui-kit/assets/90157528/21fccc7e-02fd-4933-917f-c7d037ccc8aa)

BTW : you don't see the mouse on video but it is here ^^

By default it is true. We don't need to modify the code in our existing code base to make the feature functional. 
Possible to disable hover using the following param : 

``` 
toggleHover={false}
```