### PR TITLE
add button type to dropdown

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -89,6 +89,7 @@ export function Dropdown(props: IDropdownProps) {
       <button
         data-testid={`dropdown-button`}
         onClick={toggleDropdown}
+        type="button"
         className={`flex default-button border-secondary justify-between
                     ${customButtonClass}
                     items-center text-f-primary bg-secondary


### PR DESCRIPTION
we add a button type to the drop down, because there is a bug in the bridge interface, where if we hit enter on the transfer form it opens the dropdown