### PR TITLE
Fix Safari Dropdown bug

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -19,7 +19,7 @@ interface IDropdownProps extends ComponentPropsWithoutRef<'div'> {
 }
 
 function Icon({ toggle }: { toggle: boolean }) {
-  let IconclassName = 'w-6 h-6 min-w-fit stroke-current';
+  let IconclassName = 'max-w-fit stroke-current';
 
   return toggle ? (
     <FiChevronUp className={IconclassName} />


### PR DESCRIPTION
Safari : 
<img width="1210" alt="Screenshot 2023-08-16 at 17 19 36" src="https://github.com/massalabs/ui-kit/assets/90157528/5966d055-5fe0-4c43-b79e-5dcdc6764e9c">

firefox : 
<img width="961" alt="Screenshot 2023-08-16 at 17 20 11" src="https://github.com/massalabs/ui-kit/assets/90157528/26fb8031-d119-4f07-8057-93a2c7334a56">

Chrome :
<img width="926" alt="Screenshot 2023-08-16 at 17 20 58" src="https://github.com/massalabs/ui-kit/assets/90157528/3850f549-a722-47d4-a9b0-2ca4db2bf375">

