### PR TITLE
Add auto close dropdown when leave component

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -1,9 +1,10 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 
 import { ComponentPropsWithoutRef, useState, MouseEvent } from 'react';
 import { FiChevronDown, FiChevronUp } from 'react-icons/fi';
+import useClickOutside from '../../util/useClickOutside';
 
 interface IOption extends ComponentPropsWithoutRef<'div'> {
   icon?: JSX.Element;
@@ -31,6 +32,8 @@ function Icon({ toggle }: { toggle: boolean }) {
 export function Dropdown(props: IDropdownProps) {
   let { size = 'md', select = 0, options, readOnly = false } = props;
 
+  const ref = useRef(null);
+
   const classes = {
     xs: {
       button: 'w-full px-3 py-4 h-7 rounded hover:rounded',
@@ -50,6 +53,10 @@ export function Dropdown(props: IDropdownProps) {
   const [toggle, setToggle] = useState(false);
   const [selected, setSelected] = useState(firstObject);
   const hidden = toggle ? '' : 'hidden';
+
+  useClickOutside(ref, () => {
+    setToggle(false);
+  });
 
   // refresh the selected item when the select prop changes
   useEffect(() => {
@@ -79,7 +86,7 @@ export function Dropdown(props: IDropdownProps) {
   }
 
   return (
-    <div className="relative flex-none" data-testid="dropdown">
+    <div ref={ref} className="relative flex-none" data-testid="dropdown">
       {readOnly && (
         <div
           className={`bg-primary absolute flex-none opacity-50 ${customButtonClass}`}

--- a/src/util/useClickOutside.ts
+++ b/src/util/useClickOutside.ts
@@ -1,0 +1,25 @@
+import { useEffect, RefObject } from 'react';
+
+function useClickOutside<T extends HTMLElement = HTMLElement>(
+  ref: RefObject<T>,
+  handler: (event: MouseEvent | TouchEvent) => void,
+) {
+  useEffect(() => {
+    const listener = (event: MouseEvent | TouchEvent) => {
+      if (!ref.current || ref.current.contains(event.target as Node)) {
+        return;
+      }
+      handler(event);
+    };
+
+    document.addEventListener('mousedown', listener);
+    document.addEventListener('touchstart', listener);
+
+    return () => {
+      document.removeEventListener('mousedown', listener);
+      document.removeEventListener('touchstart', listener);
+    };
+  }, [ref, handler]);
+}
+
+export default useClickOutside;


### PR DESCRIPTION
When users leave/click out of the dropdown it remains open until a new click on it. 

This MR fixes that!

We are now able to click anywhere to have it closed.